### PR TITLE
set a default boolean value for verbose logging

### DIFF
--- a/resources/conf/MacShrew.conf
+++ b/resources/conf/MacShrew.conf
@@ -1,6 +1,6 @@
 [UI]
 profile =
-verboselogging =
+verboselogging = off
 [IKE]
 ikedpath = /usr/local/sbin/iked
 ikecpath = /usr/local/bin/ikec


### PR DESCRIPTION
The reason the application is crashing is due to this not being set.

To fix issue #3 